### PR TITLE
msm: camera: Fix out-of-bounds read in string class name

### DIFF
--- a/drivers/media/platform/msm/camera_v2/jpeg_10/msm_jpeg_dev.c
+++ b/drivers/media/platform/msm/camera_v2/jpeg_10/msm_jpeg_dev.c
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2017, The Linux Foundation. All rights reserved.
+/* Copyright (c) 2012-2015, The Linux Foundation. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 and
@@ -31,6 +31,8 @@
 
 #define MSM_JPEG_NAME "jpeg"
 #define DEV_NAME_LEN 10
+
+static char devname[DEV_NAME_LEN];
 
 static int msm_jpeg_open(struct inode *inode, struct file *filp)
 {
@@ -71,8 +73,8 @@ static long msm_jpeg_compat_ioctl(struct file *filp, unsigned int cmd,
 	int rc;
 	struct msm_jpeg_device *pgmn_dev = filp->private_data;
 
-	JPEG_DBG("%s:%d] cmd=%d pgmn_dev=0x%pK arg=0x%lx\n", __func__,
-		__LINE__, _IOC_NR(cmd), pgmn_dev,
+	JPEG_DBG("%s:%d] cmd=%d pgmn_dev=0x%lx arg=0x%lx\n", __func__,
+		__LINE__, _IOC_NR(cmd), (unsigned long)pgmn_dev,
 	(unsigned long)arg);
 
 	rc = __msm_jpeg_compat_ioctl(pgmn_dev, cmd, arg);
@@ -87,8 +89,8 @@ static long msm_jpeg_ioctl(struct file *filp, unsigned int cmd,
 	int rc;
 	struct msm_jpeg_device *pgmn_dev = filp->private_data;
 
-	JPEG_DBG("%s:%d] cmd=%d pgmn_dev=0x%pK arg=0x%lx\n", __func__,
-		__LINE__, _IOC_NR(cmd), pgmn_dev,
+	JPEG_DBG("%s:%d] cmd=%d pgmn_dev=0x%lx arg=0x%lx\n", __func__,
+		__LINE__, _IOC_NR(cmd), (unsigned long)pgmn_dev,
 	(unsigned long)arg);
 
 	rc = __msm_jpeg_ioctl(pgmn_dev, cmd, arg);
@@ -114,9 +116,9 @@ int msm_jpeg_subdev_init(struct v4l2_subdev *jpeg_sd)
 	struct msm_jpeg_device *pgmn_dev =
 		(struct msm_jpeg_device *)jpeg_sd->host_priv;
 
-	JPEG_DBG("%s:%d: jpeg_sd=0x%lx pgmn_dev=0x%pK\n",
+	JPEG_DBG("%s:%d: jpeg_sd=0x%lx pgmn_dev=0x%lx\n",
 		__func__, __LINE__, (unsigned long)jpeg_sd,
-		pgmn_dev);
+		(unsigned long)pgmn_dev);
 	rc = __msm_jpeg_open(pgmn_dev);
 	JPEG_DBG("%s:%d: rc=%d\n",
 		__func__, __LINE__, rc);
@@ -132,7 +134,7 @@ static long msm_jpeg_subdev_ioctl(struct v4l2_subdev *sd,
 
 	JPEG_DBG("%s: cmd=%d\n", __func__, cmd);
 
-	JPEG_DBG("%s: pgmn_dev 0x%pK", __func__, pgmn_dev);
+	JPEG_DBG("%s: pgmn_dev 0x%lx", __func__, (unsigned long)pgmn_dev);
 
 	JPEG_DBG("%s: Calling __msm_jpeg_ioctl\n", __func__);
 
@@ -146,7 +148,7 @@ void msm_jpeg_subdev_release(struct v4l2_subdev *jpeg_sd)
 	int rc;
 	struct msm_jpeg_device *pgmn_dev =
 		(struct msm_jpeg_device *)jpeg_sd->host_priv;
-	JPEG_DBG("%s:pgmn_dev=0x%pK", __func__, pgmn_dev);
+	JPEG_DBG("%s:pgmn_dev=0x%lx", __func__, (unsigned long)pgmn_dev);
 	rc = __msm_jpeg_release(pgmn_dev);
 	JPEG_DBG("%s:rc=%d", __func__, rc);
 }
@@ -185,7 +187,6 @@ static int msm_jpeg_init_dev(struct platform_device *pdev)
 	struct msm_jpeg_device *msm_jpeg_device_p;
 	const struct of_device_id *device_id;
 	const struct msm_jpeg_priv_data *priv_data;
-	char devname[DEV_NAME_LEN];
 
 	msm_jpeg_device_p = kzalloc(sizeof(struct msm_jpeg_device), GFP_ATOMIC);
 	if (!msm_jpeg_device_p) {
@@ -261,7 +262,7 @@ static int msm_jpeg_init_dev(struct platform_device *pdev)
 		goto fail_4;
 	}
 
-	platform_set_drvdata(pdev, msm_jpeg_device_p);
+	platform_set_drvdata(pdev, &msm_jpeg_device_p);
 
 	JPEG_DBG("%s %s%d: success\n", __func__, MSM_JPEG_NAME, pdev->id);
 


### PR DESCRIPTION
jpeg driver is calling class_create with stack variable, which
can be overwritten by other stack variables.

Bug: 114041685